### PR TITLE
Add flight plan data models

### DIFF
--- a/flight_plan/__init__.py
+++ b/flight_plan/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/flight_plan/__manifest__.py
+++ b/flight_plan/__manifest__.py
@@ -1,0 +1,9 @@
+{
+    "name": "Flight Plan",
+    "summary": "Models for storing flight plan routes and waypoints",
+    "version": "18.0.1.0.0",
+    "license": "LGPL-3",
+    "author": "Apexive Solutions LLC",
+    "depends": ["flight", "flight_event"],
+    "data": ["security/ir.model.access.csv"],
+}

--- a/flight_plan/models/__init__.py
+++ b/flight_plan/models/__init__.py
@@ -1,0 +1,4 @@
+from . import flight_plan
+from . import flight_plan_route
+from . import flight_route_waypoint
+from . import flight_plan_aerodrome

--- a/flight_plan/models/flight_plan.py
+++ b/flight_plan/models/flight_plan.py
@@ -1,0 +1,29 @@
+from odoo import fields, models
+
+
+class FlightPlan(models.Model):
+    _name = "flight.plan"
+    _description = "Flight Plan"
+    _inherit = ["flight.lock.mixin"]
+
+    flight_id = fields.Many2one("flight.flight", required=True, index=True)
+    version_number = fields.Integer()
+    timestamp = fields.Datetime()
+
+    remarks = fields.Json()
+    flight_plan_header = fields.Json()
+    fuel_header = fields.Json()
+    weight_header = fields.Json()
+
+    route_id = fields.Many2one("flight.plan.route")
+    alternate_plan_ids = fields.Many2many(
+        "flight.plan",
+        "flight_plan_alternate_rel",
+        "plan_id",
+        "alternate_id",
+        string="Alternate Plans",
+    )
+
+    aerodrome_ids = fields.One2many(
+        "flight.plan.aerodrome", "plan_id", string="Aerodromes"
+    )

--- a/flight_plan/models/flight_plan_aerodrome.py
+++ b/flight_plan/models/flight_plan_aerodrome.py
@@ -1,0 +1,20 @@
+from odoo import fields, models
+
+
+class FlightPlanAerodrome(models.Model):
+    _name = "flight.plan.aerodrome"
+    _description = "Flight Plan Aerodrome"
+
+    plan_id = fields.Many2one("flight.plan", required=True, ondelete="cascade")
+    aerodrome_id = fields.Many2one("flight.aerodrome", required=True)
+    function = fields.Selection(
+        [
+            ("departure", "Departure"),
+            ("arrival", "Arrival"),
+            ("departure_alternate", "Departure Alternate"),
+            ("primary_arrival_alternate", "Primary Arrival Alternate"),
+        ],
+        required=True,
+    )
+    planned_runway = fields.Char()
+    terminal_procedure = fields.Json()

--- a/flight_plan/models/flight_plan_route.py
+++ b/flight_plan/models/flight_plan_route.py
@@ -1,0 +1,20 @@
+from odoo import fields, models
+
+
+class FlightPlanRoute(models.Model):
+    _name = "flight.plan.route"
+    _description = "Flight Plan Route"
+
+    plan_id = fields.Many2one("flight.plan", required=True, ondelete="cascade")
+    route_type = fields.Selection(
+        [
+            ("flight", "Flight"),
+            ("fms", "FMS"),
+            ("alternate", "Alternate"),
+        ],
+        default="flight",
+        required=True,
+    )
+    waypoint_ids = fields.One2many(
+        "flight.route.waypoint", "route_id", string="Waypoints"
+    )

--- a/flight_plan/models/flight_route_waypoint.py
+++ b/flight_plan/models/flight_route_waypoint.py
@@ -1,0 +1,17 @@
+from odoo import fields, models
+
+
+class FlightRouteWaypoint(models.Model):
+    _name = "flight.route.waypoint"
+    _description = "Flight Route Waypoint"
+    _order = "sequence, id"
+
+    route_id = fields.Many2one(
+        "flight.plan.route", required=True, ondelete="cascade", index=True
+    )
+    sequence = fields.Integer(default=10)
+    name = fields.Char()
+    description = fields.Char()
+    latitude = fields.Float()
+    longitude = fields.Float()
+    icao_country_code = fields.Char(size=2)

--- a/flight_plan/security/ir.model.access.csv
+++ b/flight_plan/security/ir.model.access.csv
@@ -1,0 +1,17 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_flight_plan_manager,flight.plan.manager,model_flight_plan,flight.group_flight_manager,1,1,1,1
+access_flight_plan_dispatcher,flight.plan.dispatcher,model_flight_plan,flight.group_flight_dispatcher,1,1,1,1
+access_flight_plan_crew,flight.plan.crew,model_flight_plan,flight.group_flight_crew,1,0,0,0
+access_flight_plan_user,flight.plan.user,model_flight_plan,flight.group_flight_user,1,0,0,0
+access_flight_plan_route_manager,flight.plan.route.manager,model_flight_plan_route,flight.group_flight_manager,1,1,1,1
+access_flight_plan_route_dispatcher,flight.plan.route.dispatcher,model_flight_plan_route,flight.group_flight_dispatcher,1,1,1,1
+access_flight_plan_route_crew,flight.plan.route.crew,model_flight_plan_route,flight.group_flight_crew,1,0,0,0
+access_flight_plan_route_user,flight.plan.route.user,model_flight_plan_route,flight.group_flight_user,1,0,0,0
+access_flight_route_waypoint_manager,flight.route.waypoint.manager,model_flight_route_waypoint,flight.group_flight_manager,1,1,1,1
+access_flight_route_waypoint_dispatcher,flight.route.waypoint.dispatcher,model_flight_route_waypoint,flight.group_flight_dispatcher,1,1,1,1
+access_flight_route_waypoint_crew,flight.route.waypoint.crew,model_flight_route_waypoint,flight.group_flight_crew,1,0,0,0
+access_flight_route_waypoint_user,flight.route.waypoint.user,model_flight_route_waypoint,flight.group_flight_user,1,0,0,0
+access_flight_plan_aerodrome_manager,flight.plan.aerodrome.manager,model_flight_plan_aerodrome,flight.group_flight_manager,1,1,1,1
+access_flight_plan_aerodrome_dispatcher,flight.plan.aerodrome.dispatcher,model_flight_plan_aerodrome,flight.group_flight_dispatcher,1,1,1,1
+access_flight_plan_aerodrome_crew,flight.plan.aerodrome.crew,model_flight_plan_aerodrome,flight.group_flight_crew,1,0,0,0
+access_flight_plan_aerodrome_user,flight.plan.aerodrome.user,model_flight_plan_aerodrome,flight.group_flight_user,1,0,0,0


### PR DESCRIPTION
## Summary
- add new `flight_plan` module for basic flight plan storage
- model routes, waypoints, and aerodrome references

## Testing
- `ruff check flight_plan`
- `./run_tests.sh` *(fails: //.venv/bin/activate: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a1dbbf9524832e85c280f12f3a76ae